### PR TITLE
Fix reference to uid in tile-reduce job

### DIFF
--- a/oqt-user-experience/map.js
+++ b/oqt-user-experience/map.js
@@ -7,7 +7,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     var users = {};
 
     layer.features.forEach(function(val) {
-        var user = val.properties._uid;
+        var user = val.properties['@uid'];
         if (!users[user])
             users[user] = { objects:0, highways: 0.0, buildings: 0 };
         users[user].objects += 1;


### PR DESCRIPTION
This PR applies the same change merged in https://github.com/hotosm/osm-analytics-cruncher/commit/24d3c09083b300d22e94f41891892ba8df54c547 for `oqt-user-experience/map.js` so it can successfully build the experience.json file with new QA Tiles.

This is the last file that needed the change:

``` bash
➜  osm-analytics-cruncher git:(fix-user-ref) ✗ grep -r '_uid' . --exclude-dir=node_modules
Binary file ./buildings.mbtiles matches
Binary file ./highways.mbtiles matches
./oqt-filter/map.js:            _uid : props['@uid'],
```

cc: @tyrasd 
