### PR TITLE
[WIP] Uploading tiles to Mapbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lineclip": "^1.1.5",
     "lodash": "^4.10.0",
     "mapbox-tile-copy": "^4.4.0",
+    "mapbox-upload": "^4.2.2",
     "mbtiles": "^0.8.2",
     "queue-async": "^1.2.1",
     "rbush": "^1.4.2",

--- a/upload.sh
+++ b/upload.sh
@@ -5,5 +5,5 @@
 # export MapboxAccessToken=<access token with uploads:write scope enabled>
 # ./upload.sh rodowi
 
-npm install --global mapbox-upload
-mapbox-upload $1.osm-analytics-buildings buildings.mbtiles
+node_modules/mapbox-upload/bin/upload.js $1.osm-analytics-buildings buildings.mbtiles
+

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+# usage: ./upload.sh mapbox-username
+# set a MapboxAccessToken environment variable before running, e.g.
+# export MapboxAccessToken=<access token with uploads:write scope enabled>
+# ./upload.sh rodowi
+
+npm install --global mapbox-upload
+mapbox-upload $1.osm-analytics-buildings buildings.mbtiles


### PR DESCRIPTION
This PR is a proof-of-concept of the suggestions derived from https://github.com/hotosm/osm-analytics-cruncher/issues/4#issuecomment-245405762.

Basically we are testing a new architecture where we would serve tiles from Mapbox instead of a EC2 tile server.

Related issues: #4, #7 

cc: @tyrasd @cgiovando @dodobas
