### PR TITLE
add user ids to set of sampled data fields

### DIFF
--- a/app/src/crunch/map.js
+++ b/app/src/crunch/map.js
@@ -171,7 +171,8 @@ module.exports = function _(tileLayers, tile, writeData, done) {
                 binObjects[index].push({
                     //id: feature.properties._osm_way_id, // todo: rels??
                     _timestamp: feature.properties._timestamp,
-                    _userExperience: feature.properties._userExperience
+                    _userExperience: feature.properties._userExperience,
+                    _uid: feature.properties._uid
                 });
             });
         });
@@ -195,6 +196,8 @@ module.exports = function _(tileLayers, tile, writeData, done) {
             feature.properties._userExperienceMin = stats.quantile(experiences, 0.25);
             feature.properties._userExperienceMax = stats.quantile(experiences, 0.75);
             feature.properties._userExperiences = lodash.sampleSize(experiences, 16).join(';');
+            var uids = lodash.map(binObjects[index], '_uid');
+            feature.properties._uids = lodash.sampleSize(uids, 16).join(';');
         });
         output.features = output.features.filter(function(feature) {
             return feature.properties._count > 0;

--- a/app/src/downscale/map.js
+++ b/app/src/downscale/map.js
@@ -169,21 +169,27 @@ function processMeta(tile, writeData, done) {
                     var binTimestamps = _bin.properties._timestamps.split(';').map(Number);
                     return prev.concat(binTimestamps.slice(0, 16*Math.round(_bin.properties._count/maxBinCount)));
                 }, []);
+                var sampleIndices = lodash.sampleSize(Array.apply(null, {length: timestamps.length}).map(Number.call, Number), 16);
                 bin.properties._timestampMin = stats.quantile(timestamps, 0.25);
                 bin.properties._timestampMax = stats.quantile(timestamps, 0.75);
-                bin.properties._timestamps = lodash.sampleSize(timestamps, 16).join(';');
+                bin.properties._timestamps = sampleIndices.map(function(idx) { return timestamps[idx]; }).join(';');
                 var experiences = _bins.reduce(function(prev, _bin) {
                     var binExperiences = _bin.properties._userExperiences.split(';').map(Number);
                     return prev.concat(binExperiences.slice(0, 16*Math.round(_bin.properties._count/maxBinCount)));
                 }, []);
                 bin.properties._userExperienceMin = stats.quantile(experiences, 0.25);
                 bin.properties._userExperienceMax = stats.quantile(experiences, 0.75);
-                bin.properties._userExperiences = lodash.sampleSize(experiences, 16).join(';');
+                bin.properties._userExperiences = sampleIndices.map(function(idx) { return experiences[idx]; }).join(';');
                 var uids = _bins.reduce(function(prev, _bin) {
                     var binUids = _bin.properties._uids.split(';').map(Number);
                     return prev.concat(binUids.slice(0, 16*Math.round(_bin.properties._count/maxBinCount)));
                 }, []);
-                bin.properties._uids = lodash.sampleSize(uids, 16).join(';');
+                bin.properties._uids = sampleIndices.map(function(idx) { return uids[idx]; }).join(';');
+                var tagValues = _bins.reduce(function(prev, _bin) {
+                    var binTagValues = _bin.properties._tagValues.split(';');
+                    return prev.concat(binTagValues.slice(0, 16*Math.round(_bin.properties._count/maxBinCount)));
+                }, []);
+                bin.properties._tagValues = sampleIndices.map(function(idx) { return tagValues[idx]; }).join(';');
 
                 output.features.push(bin);
             }

--- a/app/src/downscale/map.js
+++ b/app/src/downscale/map.js
@@ -179,6 +179,11 @@ function processMeta(tile, writeData, done) {
                 bin.properties._userExperienceMin = stats.quantile(experiences, 0.25);
                 bin.properties._userExperienceMax = stats.quantile(experiences, 0.75);
                 bin.properties._userExperiences = lodash.sampleSize(experiences, 16).join(';');
+                var uids = _bins.reduce(function(prev, _bin) {
+                    var binUids = _bin.properties._uids.split(';').map(Number);
+                    return prev.concat(binUids.slice(0, 16*Math.round(_bin.properties._count/maxBinCount)));
+                }, []);
+                bin.properties._uids = lodash.sampleSize(uids, 16).join(';');
 
                 output.features.push(bin);
             }


### PR DESCRIPTION
This adds user ids to the content of the produced osma vector tiles. They can be used to determine some estimations about OSM's contributor base for larger areas (see https://github.com/hotosm/osm-analytics/pull/88).

Closes #1

This PR also re-introduces the values for the filtered osm tags (e.g. the `primary` of `highway=primary` when the layer filters for all `highway=*` features) and adds samples for these for the lower zoom levels. This is currently not used by the osma frontend, but could be used to provide some more custom sub-filtering of feature layers at runtime.